### PR TITLE
[Programmers-완전탐색] 최소직사각형, 모의고사

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# ignore python3 interpreter environments
+/venv/
+.idea

--- a/Programmers/seungho/bruteforcing/모의고사.py
+++ b/Programmers/seungho/bruteforcing/모의고사.py
@@ -1,0 +1,21 @@
+def solution(answers):
+    answer = []
+
+    way = [[1, 2, 3, 4, 5],
+           [2, 1, 2, 3, 2, 4, 2, 5],
+           [3, 3, 1, 1, 2, 2, 4, 4, 5, 5]]
+    score = [(1, 0), (2, 0), (3, 0)]
+    for i in range(len(answers)):
+        for j in range(3):
+            if answers[i] == way[j][i % len(way[j])]:
+                score[j] = (j + 1, score[j][1] + 1)
+
+    score.sort(reverse=True, key=lambda x: x[1])
+    pick_max = score[0][1]
+    for s in score:
+        if s[1] == pick_max:
+            answer.append(s[0])
+        else:
+            break
+
+    return answer

--- a/Programmers/seungho/bruteforcing/최소직사각형.py
+++ b/Programmers/seungho/bruteforcing/최소직사각형.py
@@ -1,0 +1,10 @@
+def solution(sizes):
+    # 배열 차원 : NxM, M=2 (negligible)
+    for size in sizes:  # O(NMlogM) -> O(N)
+        size.sort(reverse=True)
+
+    max_w, max_h = 0, 0
+    for size in sizes:  # O(NM) -> O(N)
+        max_w = max(max_w, size[0])
+        max_h = max(max_h, size[1])
+    return max_w * max_h


### PR DESCRIPTION
## 최소직사각형
### 접근법
- 카드를 긴쪽이 가로로 오도록 모두 돌려놓습니다. 즉, 모든 배열을 [큰수, 작은수] 형태로 맞춰놓습니다. 
    - N개의 [W, H]에 대해 정렬하는 것은 O(N * 2log2)인데, 2log2는 상수 term으로 무시
- N개의 [큰수, 작은수]에서, 큰수 중에서 가장 큰 수를 max_w로 잡습니다.
- N개의 [큰수, 작은수]에서, 작은수 중에서 가장 큰 수를 max_h로 잡습니다.
    - 파이썬 max 연산은 O(N) 비교 
```python3
def solution(sizes):
    # 배열 차원 : NxM, M=2 (negligible)
    for size in sizes:  # O(NMlogM) -> O(N)
        size.sort(reverse=True)

    max_w, max_h = 0, 0
    for size in sizes:  # O(NM) -> O(N)
        max_w = max(max_w, size[0])
        max_h = max(max_h, size[1])
    return max_w * max_h
```

## 모의고사
### 접근법
- 주어진 찍기 패턴이 미리 정해져있고 얼마 되지도 않으니까, 패턴 한 사이클을 미리 way 가변길이 리스트로 fix 해놓습니다.
- score에는 [(수포자1, 0점), (수포자2, 0점), (수포자3, 0점)] 형태의 튜플 리스트로 초기화합니다.
- `if answers[i] == way[j][i % len(way[j])]:`에서, i번째 정답에 대해 수포자 j가 쓴 답이 일치하는지 검사하고, 맞다면 score를 1 올려줍니다.
    - 튜플 값 변경 대신 재할당 해줍니다.
- score를 점수 기준으로 정렬하고, 최대 점수를 얻은 사람들을 모두 answer에 넣습니다.
    - 단, 정렬 안정성이 보장되어야 함. 언어별로 sort()가 unstable하게 구현될수도 잇음. (각자 체크필요)
    - 불안정정렬이라면 키를 2개 써서 정렬해줘야 할것같음.
```python3 
def solution(answers):
    answer = []

    way = [[1, 2, 3, 4, 5],
           [2, 1, 2, 3, 2, 4, 2, 5],
           [3, 3, 1, 1, 2, 2, 4, 4, 5, 5]]
    score = [(1, 0), (2, 0), (3, 0)]
    for i in range(len(answers)): # O(N)
        for j in range(3):
            if answers[i] == way[j][i % len(way[j])]:
                score[j] = (j + 1, score[j][1] + 1)

    score.sort(reverse=True, key=lambda x: x[1]) # O(NlogN)
    pick_max = score[0][1]
    for s in score: # O(N) in the worst case
        if s[1] == pick_max:
            answer.append(s[0])
        else:
            break

    return answer
```
