### PR TITLE
[Programmers-DFS/BFS] 게임 맵 최단거리, 타겟 넘버

### DIFF
--- a/Programmers/seungho/dfs-bfs/게임 맵 최단거리.py
+++ b/Programmers/seungho/dfs-bfs/게임 맵 최단거리.py
@@ -1,0 +1,36 @@
+import collections
+
+dr = [-1, 0, 1, 0]
+dc = [0, 1, 0, -1]
+
+
+def bfs(maps):
+    q = collections.deque()
+    q.append((0, 0))
+    visit = set()
+    visit.add((0, 0))
+
+    count = 1
+    while q:
+        qsize = len(q)
+        for i in range(qsize):
+            r, c = q.popleft()
+            for d in range(4):
+                nr, nc = r + dr[d], c + dc[d]
+                if not (0 <= nr < len(maps) and 0 <= nc < len(maps[0])):
+                    continue
+                if maps[nr][nc] == 0:
+                    continue
+                if (nr, nc) in visit:
+                    continue
+                if (nr, nc) == (len(maps) - 1, len(maps[0]) - 1):
+                    return count + 1
+                visit.add((nr, nc))
+                q.append((nr, nc))
+        count += 1
+    return -1
+
+
+def solution(maps):
+    answer = bfs(maps)
+    return answer

--- a/Programmers/seungho/dfs-bfs/타겟 넘버.py
+++ b/Programmers/seungho/dfs-bfs/타겟 넘버.py
@@ -1,0 +1,21 @@
+found = 0
+
+
+def dfs(numbers, idx, acc, target, depth):
+    global found
+
+    if depth == 0:
+        if acc == target:
+            found += 1
+        return
+
+    dfs(numbers, idx + 1, acc + numbers[idx], target, depth - 1)
+    dfs(numbers, idx + 1, acc - numbers[idx], target, depth - 1)
+
+
+def solution(numbers, target):
+    global found
+
+    dfs(numbers, 0, 0, target, len(numbers))
+
+    return found


### PR DESCRIPTION
## 타겟 넘버
### DFS
- 재귀적으로 모든 경우를 찾습니다. 
- 재귀함수를 구성할 때 필요한 인자들을 잘 설정해줍니다. 
    - 종료조건 판별 위한 depth
    - 중간 계산 결과를 담기 위한 acc
    - 다음 인덱스 위치를 재귀함수에게 전달하기 위한 idx
- 빼는 분기/더하는 분기를 차례로 호출합니다.
```python3
found = 0


def dfs(numbers, idx, acc, target, depth):
    global found

    if depth == 0:
        if acc == target:
            found += 1
        return

    dfs(numbers, idx + 1, acc + numbers[idx], target, depth - 1)
    dfs(numbers, idx + 1, acc - numbers[idx], target, depth - 1)
```

## 게임 맵 최단거리
### BFS
- BFS로 모든 경우를 탐색합니다.
- item이 q로 들어갈 때는 시작점으로부터 얼마나 떨어진 거리인가에 대한 정보가 없습니다. 따라서 qsize를 매번 구하고 그만큼 for-loop를 걸어줍니다. 루프 안에서 q.pop, validation, push 로직을 처리합니다. 이로써 for-loop을 경계로 거리가 구분됩니다.
```python3
dr = [-1, 0, 1, 0]
dc = [0, 1, 0, -1]


def bfs(maps):
    q = collections.deque()
    q.append((0, 0))
    visit = set()
    visit.add((0, 0))

    count = 1
    while q:
        qsize = len(q)
        for i in range(qsize):
            r, c = q.popleft()
            for d in range(4):
                nr, nc = r + dr[d], c + dc[d]
                if not (0 <= nr < len(maps) and 0 <= nc < len(maps[0])):
                    continue
                if maps[nr][nc] == 0:
                    continue
                if (nr, nc) in visit:
                    continue
                if (nr, nc) == (len(maps) - 1, len(maps[0]) - 1):
                    return count + 1
                visit.add((nr, nc))
                q.append((nr, nc))
        count += 1
    return -1
```
