### PR TITLE
[Programmers-Graph] 가장 먼 노드, 순위

### DIFF
--- a/Programmers/seungho/graph/가장 먼 노드.py
+++ b/Programmers/seungho/graph/가장 먼 노드.py
@@ -1,0 +1,38 @@
+import heapq
+
+
+def dijkstra(adj, n):
+    INF = -1
+    dist = [INF for _ in range(n + 1)]
+    dist[1] = 0
+    hq = []
+    heapq.heappush(hq, (0, 1))
+
+    while hq:
+        w, v = heapq.heappop(hq)
+
+        for nw, nv in adj[v]:
+            if dist[nv] == INF or dist[nv] > dist[v] + nw:
+                dist[nv] = dist[v] + nw
+                heapq.heappush(hq, (dist[nv], nv))
+
+    return dist
+
+
+def solution(n, edge):
+    answer = 0
+
+    adj = [[] for _ in range(n + 1)]
+    for e in edge:
+        v1, v2 = e
+        adj[v1].append((1, v2))
+        adj[v2].append((1, v1))
+
+    dist = dijkstra(adj, n)
+    maximum = max(dist)
+
+    for d in dist:
+        if d == maximum:
+            answer += 1
+
+    return answer

--- a/Programmers/seungho/graph/순위.py
+++ b/Programmers/seungho/graph/순위.py
@@ -1,0 +1,37 @@
+INF = 2147483647
+
+
+def floyd_warshall(n, results):
+    global INF
+
+    adj = [[INF for _ in range(n)] for _ in range(n)]
+
+    for i in range(n):
+        adj[i][i] = 0
+
+    for r in results:
+        winner, loser = r[0] - 1, r[1] - 1
+        adj[winner][loser] = 1
+
+    for i in range(n):
+        for j in range(n):
+            for k in range(n):
+                adj[j][k] = min(adj[j][k], adj[j][i] + adj[i][k])
+    return adj
+
+
+def solution(n, results):
+    global INF
+
+    answer = 0
+    adj = floyd_warshall(n, results)
+
+    for i in range(len(adj)):
+        count = 0
+        for j in range(len(adj[i])):
+            if adj[i][j] != INF or adj[j][i] != INF:
+                count += 1
+        if count == n:
+            answer += 1
+
+    return answer


### PR DESCRIPTION
## 가장 먼 노드
### 다익스트라 최단경로
- 시작점이 노드1로 고정이고, 가장 먼 거리에 떨어진 노드 개수만 세면 되므로, 모든 노드 간 가중치=1인 다익스트라 최단경로 문제로 접근해봤습니다. 
```python3
def dijkstra(adj, n):
    INF = 2147483647
    dist = [INF for _ in range(n + 1)]
    dist[1] = 0
    hq = []
    heapq.heappush(hq, (0, 1))

    while hq:
        w, v = heapq.heappop(hq)

        for nw, nv in adj[v]:
            if dist[nv] > dist[v] + nw:
                dist[nv] = dist[v] + nw
                heapq.heappush(hq, (dist[nv], nv))

    return dist
```
## 순위
### 플로이드-워셜 최단경로
- A가 C를 이기고, C가 B를 이겼다는 기록이 있으면 A는 B를 이기게 됨을 유추해야 합니다. 승패관계는 단방향 그래프로 표현됩니다. 초기 거리 배열에서  A->B는 무한대로 설정되었을 것이고, 승패기록에서 A->C, C->B 값이 있다면 A->B는 [(A->C) + (C->B)]로 업데이트될 수 있는 점에서 플로이드-워셜 알고리즘을 썼습니다.
```python3
def floyd_warshall(n, results):
    INF = 2147483647

    adj = [[INF for _ in range(n)] for _ in range(n)]

    for i in range(n):
        adj[i][i] = 0

    for r in results:
        winner, loser = r[0] - 1, r[1] - 1
        adj[winner][loser] = 1

    for i in range(n):
        for j in range(n):
            for k in range(n):
                adj[j][k] = min(adj[j][k], adj[j][i] + adj[i][k])
    return adj
```